### PR TITLE
WIP Batch hdf attributes

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -185,9 +185,9 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
       extendIndexDataSet(offsets[indexed]);
     }
     // find the data based on datatype
-    ret = ndAttr->getValue(ndAttr->getDataType(), pDatavaluestore[dataset_count], MAX_ATTRIBUTE_STRING_SIZE);
+    ret = ndAttr->getValue(ndAttr->getDataType(), pDataValueStore_[dataset_count], MAX_ATTRIBUTE_STRING_SIZE);
     if (ret == ND_ERROR) {
-      memset(pDatavaluestore[dataset_count], 0, MAX_ATTRIBUTE_STRING_SIZE);
+      memset(pDataValueStore_[dataset_count], 0, MAX_ATTRIBUTE_STRING_SIZE);
     }
     dataset_count++;
     // Check if we are being asked to flush or if the size of the store has reached its maximum amount
@@ -201,7 +201,7 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
       memspace_ = H5Screate_simple(rank_, elementSize_, NULL);
       // Select the hyperslab
       H5Sselect_hyperslab(filespace_, H5S_SELECT_SET, offset_, NULL, elementSize_, NULL);
-      H5Dwrite(dataset_, datatype_, memspace_, filespace_, H5P_DEFAULT, pDatavaluestore);
+      H5Dwrite(dataset_, datatype_, memspace_, filespace_, H5P_DEFAULT, pDataValueStore_);
       if (flush ==1)
         status = this->flushDataset();
       H5Sclose(filespace_);
@@ -229,7 +229,7 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(int close)
     memspace_ = H5Screate_simple(rank_, elementSize_, NULL);
     // Select the hyperslab
     H5Sselect_hyperslab(filespace_, H5S_SELECT_SET, offset_, NULL, elementSize_, NULL);
-    H5Dwrite(dataset_, datatype_, memspace_, filespace_, H5P_DEFAULT, pDatavaluestore);
+    H5Dwrite(dataset_, datatype_, memspace_, filespace_, H5P_DEFAULT, pDataValueStore_);
     H5Sclose(filespace_);
     dataset_count = 0;
   }

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -170,7 +170,11 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
     // find the data based on datatype
     if (write == 1){
       writeAttributeDatasetBatch(flush, write);
-      ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      if (ndAttr->getDataType() != NDAttrString)
+        ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      else{
+        ret = ndAttr->getValue(NDAttrString, pStringDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      }
       if (ret == ND_ERROR) {
         memset(pDataValueStore_[attributeBatchCount_], 0, MAX_ATTRIBUTE_STRING_SIZE);
       }
@@ -183,7 +187,11 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
     else{
       for (int i=extraDimensions_ - 1; i>=0; --i)
         lastOffset_[i] = offset_[i];
-      ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      if (ndAttr->getDataType() != NDAttrString)
+        ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      else{
+        ret = ndAttr->getValue(NDAttrString, pStringDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      }
       if (ret == ND_ERROR) {
         memset(pDataValueStore_[attributeBatchCount_], 0, MAX_ATTRIBUTE_STRING_SIZE);
       }
@@ -236,7 +244,11 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
     // find the data based on datatype
     if (write == 1){
       writeAttributeDatasetBatch(flush, write);
-      ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      if (ndAttr->getDataType() != NDAttrString)
+        ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      else{
+        ret = ndAttr->getValue(NDAttrString, pStringDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      }
       if (ret == ND_ERROR) {
         memset(pDataValueStore_[attributeBatchCount_], 0, MAX_ATTRIBUTE_STRING_SIZE);
       }
@@ -247,7 +259,11 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDataset(hdf5::When_t whenTo
     else{
       for (int i=extraDimensions_ - 1; i>=0; --i)
         lastOffset_[i] = offset_[i];
-      ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      if (ndAttr->getDataType() != NDAttrString)
+        ret = ndAttr->getValue(NDAttrFloat64, pDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      else{
+        ret = ndAttr->getValue(NDAttrString, pStringDataValueStore_[attributeBatchCount_], MAX_ATTRIBUTE_STRING_SIZE);
+      }
       if (ret == ND_ERROR) {
         memset(pDataValueStore_[attributeBatchCount_], 0, MAX_ATTRIBUTE_STRING_SIZE);
       }
@@ -290,7 +306,11 @@ asynStatus NDFileHDF5AttributeDataset::writeAttributeDatasetBatch(int flush, int
     memspace_ = H5Screate_simple(rank_, elementSize_, NULL);
     // Select the hyperslab
     H5Sselect_hyperslab(filespace_, H5S_SELECT_SET, offset_, NULL, elementSize_, NULL);
-    H5Dwrite(dataset_, H5T_NATIVE_DOUBLE, memspace_, filespace_, H5P_DEFAULT, pDataValueStore_);
+    if (type_ == NDAttrString){
+      H5Dwrite(dataset_, datatype_, memspace_, filespace_, H5P_DEFAULT, pStringDataValueStore_);
+    }
+    else
+      H5Dwrite(dataset_, H5T_NATIVE_DOUBLE, memspace_, filespace_, H5P_DEFAULT, pDataValueStore_);
     if(flush ==1)
       status = this->flushDataset();
     H5Sclose(filespace_);

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -28,7 +28,7 @@ public:
   void setParentGroupName(const std::string& group);
   asynStatus createDataset(int user_chunking);
   asynStatus createDataset(bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
-  asynStatus writeAttributeDataset(int flush);
+  asynStatus writeAttributeDataset(int close);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, NDAttribute *ndAttr, int flush);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, hsize_t *offsets, NDAttribute *ndAttr, int flush, int indexed);
   asynStatus closeAttributeDataset();

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -73,6 +73,8 @@ private:
   int              attributeBatchCount_;
   hsize_t          *dataStoreOffset_;
   int              ammendedMaxBatchCount_;
+  hsize_t          *lastOffset_;
+  int              completeLine_;
 };
 
 #endif /* ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_ */

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -44,7 +44,6 @@ private:
   void extendDataSet();
   void extendDataSet(hsize_t *offsets);
   void extendIndexDataSet(hsize_t offset);
-  // void calculateMaxBatchSize();
 
   std::string      name_;            // Name of the attribute
   std::string      dsetName_;        // Name of the dataset to store
@@ -72,7 +71,6 @@ private:
   void             *pDataValueStore_[MAX_BATCH_SIZE][1];
   char             pStringDataValueStore_[MAX_BATCH_SIZE][256];
   int              attributeBatchCount_;
-  hsize_t          *dataStoreOffset_;
   int              ammendedMaxBatchCount_;
   hsize_t          *lastOffset_;
   hsize_t          *offsetDiff_;

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -8,6 +8,7 @@
 #ifndef ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_
 #define ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_
 
+#define FLUSH_SIZE 1000
 #include <string>
 #include <hdf5.h>
 #include <asynDriver.h>
@@ -66,7 +67,8 @@ private:
   int              nextRecord_;
   int              extraDimensions_;
   hdf5::When_t     whenToSave_;
-
+  void             *pDatavaluestore[FLUSH_SIZE][1];
+  int              dataset_count;
 };
 
 #endif /* ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_ */

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -28,7 +28,6 @@ public:
   void setParentGroupName(const std::string& group);
   asynStatus createDataset(int user_chunking);
   asynStatus createDataset(bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
-  asynStatus writeAttributeDataset(int close);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, NDAttribute *ndAttr, int flush);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, hsize_t *offsets, NDAttribute *ndAttr, int flush, int indexed);
   asynStatus closeAttributeDataset();
@@ -41,6 +40,7 @@ private:
   asynStatus configureDims(int user_chunking);
   asynStatus configureDimsFromDataset(bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
   asynStatus typeAsHdf();
+  asynStatus writeAttributeDatasetBatch(int flush);
   void extendDataSet();
   void extendDataSet(hsize_t *offsets);
   void extendIndexDataSet(hsize_t offset);
@@ -69,7 +69,7 @@ private:
   int              extraDimensions_;
   hdf5::When_t     whenToSave_;
   void             *pDataValueStore_[MAX_BATCH_SIZE][1];
-  int              dataset_count;
+  int              attributeBatchCount_;
 };
 
 #endif /* ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_ */

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -8,7 +8,7 @@
 #ifndef ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_
 #define ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_
 
-#define FLUSH_SIZE 1000
+#define MAX_BATCH_SIZE 100000
 #include <string>
 #include <hdf5.h>
 #include <asynDriver.h>
@@ -28,6 +28,7 @@ public:
   void setParentGroupName(const std::string& group);
   asynStatus createDataset(int user_chunking);
   asynStatus createDataset(bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
+  asynStatus writeAttributeDataset(int flush);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, NDAttribute *ndAttr, int flush);
   asynStatus writeAttributeDataset(hdf5::When_t whenToSave, hsize_t *offsets, NDAttribute *ndAttr, int flush, int indexed);
   asynStatus closeAttributeDataset();
@@ -67,7 +68,7 @@ private:
   int              nextRecord_;
   int              extraDimensions_;
   hdf5::When_t     whenToSave_;
-  void             *pDatavaluestore[FLUSH_SIZE][1];
+  void             *pDatavaluestore[MAX_BATCH_SIZE][1];
   int              dataset_count;
 };
 

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -68,7 +68,7 @@ private:
   int              nextRecord_;
   int              extraDimensions_;
   hdf5::When_t     whenToSave_;
-  void             *pDatavaluestore[MAX_BATCH_SIZE][1];
+  void             *pDataValueStore_[MAX_BATCH_SIZE][1];
   int              dataset_count;
 };
 

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -40,11 +40,11 @@ private:
   asynStatus configureDims(int user_chunking);
   asynStatus configureDimsFromDataset(bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
   asynStatus typeAsHdf();
-  asynStatus writeAttributeDatasetBatch(int flush);
+  asynStatus writeAttributeDatasetBatch(int flush, int write);
   void extendDataSet();
   void extendDataSet(hsize_t *offsets);
   void extendIndexDataSet(hsize_t offset);
-  void calculateMaxBatchSize();
+  // void calculateMaxBatchSize();
 
   std::string      name_;            // Name of the attribute
   std::string      dsetName_;        // Name of the dataset to store
@@ -74,7 +74,9 @@ private:
   hsize_t          *dataStoreOffset_;
   int              ammendedMaxBatchCount_;
   hsize_t          *lastOffset_;
+  hsize_t          *offsetDiff_;
   int              completeLine_;
+  hsize_t          *newOffset_;
 };
 
 #endif /* ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_ */

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -70,6 +70,7 @@ private:
   int              extraDimensions_;
   hdf5::When_t     whenToSave_;
   void             *pDataValueStore_[MAX_BATCH_SIZE][1];
+  char             pStringDataValueStore_[MAX_BATCH_SIZE][256];
   int              attributeBatchCount_;
   hsize_t          *dataStoreOffset_;
   int              ammendedMaxBatchCount_;

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -75,7 +75,6 @@ private:
   int              ammendedMaxBatchCount_;
   hsize_t          *lastOffset_;
   hsize_t          *offsetDiff_;
-  int              completeLine_;
   hsize_t          *newOffset_;
 };
 

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -44,6 +44,7 @@ private:
   void extendDataSet();
   void extendDataSet(hsize_t *offsets);
   void extendIndexDataSet(hsize_t offset);
+  void calculateMaxBatchSize();
 
   std::string      name_;            // Name of the attribute
   std::string      dsetName_;        // Name of the dataset to store
@@ -70,6 +71,8 @@ private:
   hdf5::When_t     whenToSave_;
   void             *pDataValueStore_[MAX_BATCH_SIZE][1];
   int              attributeBatchCount_;
+  hsize_t          *dataStoreOffset_;
+  int              ammendedMaxBatchCount_;
 };
 
 #endif /* ADAPP_PLUGINSRC_NDFILEHDF5ATTRIBUTEDATASET_H_ */


### PR DESCRIPTION
We saw a high cpu usage when using fast detectors so instead of doing lots of H5DWrites on single float values when NDAttributes come in, we now store the NDAttributes in a chunk of memory, and only write them at flush, close, or when the chunk of memory becomes full. We then found that this improved performance at the higher data rates.