### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,3 +1,3 @@
 gitolite ssh://dascgitolite@dasc-git.diamond.ac.uk/controls/support/ADCore
-dls-controls git@github.com:dls-controls/ADCore.git
+DiamondLightSource git@github.com:DiamondLightSource/ADCore.git
 upstream git@github.com:areaDetector/ADCore.git


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/ADCore` using https://gitlab.diamond.ac.uk/github/github-scripts