### PR TITLE
Support variable character limit NDAttributesFile

### DIFF
--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -794,7 +794,7 @@ record(waveform, "$(P)$(R)NDAttributesFile")
     field(DTYP, "asynOctetWrite")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ND_ATTRIBUTES_FILE")
     field(FTVL, "CHAR")
-    field(NELM, "256")
+    field(NELM, "$(XMLSIZE=256)")
     info(autosaveFields, "VAL")
 }
 


### PR DESCRIPTION
Following https://github.com/areaDetector/ADCore/pull/503 the NDAttributesFile record can also directly contain an XML string, however the record is still limited to 256 characters, which may not be enough to accomodate a large blob of XML. This adds a macro, `XMLSIZE`, with a default of 256, so IOCs can be
configured to accomodate larger blobs of XML.